### PR TITLE
Fixed example commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,17 +98,17 @@ You can get running with:
 python cli.py --help
 
 # Build file index, takes about 20s
-python cli.py index
+python cli.py index --videos data/train/youtube_faces_with_keypoints_large.csv
 
 # Process a video, matching it against the index.
-python cli.py process-video PATH_TO_VIDEO_NPZ
+python cli.py process-video --videos data/train/youtube_faces_with_keypoints_large.csv PATH_TO_VIDEO_NPZ
 ```
 
 We also provide a baseline model that you can try by adding `--baseline` flag after `cli.py`:
-
-    python cli.py --baseline index 
-    python cli.py --baseline process-video PATH_TO_VIDEO
-
+```
+python cli.py --baseline index --videos data/train/youtube_faces_with_keypoints_large.csv
+python cli.py --baseline --videos data/train/youtube_faces_with_keypoints_large.csv PATH_TO_VIDEO_NPZ
+```
 
 ## Participating
 

--- a/README.md
+++ b/README.md
@@ -98,16 +98,16 @@ You can get running with:
 python cli.py --help
 
 # Build file index, takes about 20s
-python cli.py index --videos data/train/youtube_faces_with_keypoints_small.csv
+python cli.py index
 
 # Process a video, matching it against the index.
-python cli.py process-video -v PATH_TO_VIDEO_NPZ
+python cli.py process-video PATH_TO_VIDEO_NPZ
 ```
 
 We also provide a baseline model that you can try by adding `--baseline` flag after `cli.py`:
 
     python cli.py --baseline index 
-    python cli.py --baseline process-video -v PATH_TO_VIDEO
+    python cli.py --baseline process-video PATH_TO_VIDEO
 
 
 ## Participating


### PR DESCRIPTION
The example command with combination of "-v PATH_TO_VIDEO_NPZ" is wrong according to the code and causes 'Error: Missing argument "FILENAME"' when you run the examples.

There are 2 ways to fix this. By specifying -v (--videos) option with the csv file path or depending on the default value of "./data/youtube_faces_with_keypoints_large.csv". Previous instructions tell to `mv large_train/* train` so the .csv file will be in ./data/train not in ./data and the default value would not work anyways.

As a person trying this for the first time I personally would prefer the example which includes the option for configuring the .csv path so I don't have to read the code to get it working.